### PR TITLE
Fix app build

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     ],
     "scripts": {
         "clean": "shx rm -rf dist .parcel-cache",
-        "build": "yarn clean && parcel build src/index.html",
+        "build": "find -name retry.js -type f -exec sed -i -e 's/this.createTimeout/exports.createTimeout/g' {} \\; && yarn clean && parcel build src/index.html",
         "start": "yarn clean && parcel src/index.html",
         "fmt": "prettier --write '{*,**/*}.{js,ts,jsx,tsx,json}'",
         "lint": "eslint . && prettier --check '{*,**/*}.{js,ts,jsx,tsx,json}'",


### PR DESCRIPTION
This commit simply ensures that "this.createTimeout" is replaced by "exports.createTimeout" in the node-retry package.

This is so that we implement this PR: https://github.com/tim-kos/node-retry/pull/85 before node-retry is officially updated.